### PR TITLE
Fix issue #114

### DIFF
--- a/ManualSource/a-grammars.tex
+++ b/ManualSource/a-grammars.tex
@@ -11,7 +11,8 @@ information. However, if you don't already know what a BNF grammar is, it's
 unlikely that you have any need for this appendix.)
 
 This information is provided for advanced Soar users, for example, those who
-need to write their own parsers.
+need to write their own parsers. Note that some terms (e.g. \soar{<sym\_constant>})
+are undefined; as such, this grammar should only be used as a starting point.
 
 \comment{this section still needs a disclaimer that what you can actually do
 	is less restrictive than the way we described it in the main text } 

--- a/ManualSource/syntax.tex
+++ b/ManualSource/syntax.tex
@@ -592,7 +592,7 @@ which match in conditions to the action side of a rule.
 
 Syntactically, a variable is a symbol that begins with
 a left angle-bracket (i.e., \soar{<}), ends with a right angle-bracket (i.e.,
-\soar{>}), and contains at least one alphanumeric symbol in between.
+\soar{>}), and contains at least one non-pipe (\soar{|}) character in between.
 
 In the example production in Figure \ref{fig:ex-prod}, there are seven
 variables: \soar{<s>}, \soar{<clear1>}, \soar{<clear2>}, \soar{<ontop>},


### PR DESCRIPTION
This issue was ported into the Soar repo at https://github.com/SoarGroup/Soar/issues/114

The changes took the minimal route. The BNF grammar now contains a warning about its incompleteness, and the syntactic description of variables has been loosened.
